### PR TITLE
fix: guardar ID de sucursales en FranchiseMapper

### DIFF
--- a/data.example.json
+++ b/data.example.json
@@ -59,7 +59,8 @@
         ]
       }
     ]
-  },{
+  },
+  {
     "name": "ElectroHogar"
   },
   {

--- a/src/main/java/com/victorvivas/pruebaaccenture/accenture_franquicia_api/domain/repository/FranchiseRepository.java
+++ b/src/main/java/com/victorvivas/pruebaaccenture/accenture_franquicia_api/domain/repository/FranchiseRepository.java
@@ -21,4 +21,6 @@ public interface FranchiseRepository {
     Flux<Franchise> saveAll(Flux<Franchise> franchises);
 
     Mono<Void> deleteById(String id);
+
+    Mono<Void> deleteAll();
 }

--- a/src/main/java/com/victorvivas/pruebaaccenture/accenture_franquicia_api/entrypoints/dto/StockUpdateDTO.java
+++ b/src/main/java/com/victorvivas/pruebaaccenture/accenture_franquicia_api/entrypoints/dto/StockUpdateDTO.java
@@ -1,0 +1,13 @@
+package com.victorvivas.pruebaaccenture.accenture_franquicia_api.entrypoints.dto;
+
+public class StockUpdateDTO {
+    private int stock;
+
+    public int getStock() {
+        return stock;
+    }
+
+    public void setStock(int stock) {
+        this.stock = stock;
+    }
+}

--- a/src/main/java/com/victorvivas/pruebaaccenture/accenture_franquicia_api/infrastructure/persistence/FranchiseRepositoryImpl.java
+++ b/src/main/java/com/victorvivas/pruebaaccenture/accenture_franquicia_api/infrastructure/persistence/FranchiseRepositoryImpl.java
@@ -62,4 +62,9 @@ public class FranchiseRepositoryImpl implements FranchiseRepository {
             .map(mapper::toDomain);
     }
 
+    @Override
+    public Mono<Void> deleteAll() {
+        return reactiveRepo.deleteAll();
+    }
+
 }

--- a/src/main/java/com/victorvivas/pruebaaccenture/accenture_franquicia_api/infrastructure/persistence/mapper/FranchiseMapper.java
+++ b/src/main/java/com/victorvivas/pruebaaccenture/accenture_franquicia_api/infrastructure/persistence/mapper/FranchiseMapper.java
@@ -54,6 +54,7 @@ public class FranchiseMapper {
 
     private BranchEntity toEntity(Branch branch) {
         BranchEntity entity = new BranchEntity();
+        entity.setId(branch.getId());
         entity.setName(branch.getName());
 
         if (branch.getProducts() != null) {
@@ -70,6 +71,7 @@ public class FranchiseMapper {
 
     private Branch toDomain(BranchEntity entity) {
         Branch branch = new Branch();
+        branch.setId(entity.getId());
         branch.setName(entity.getName());
 
         if (entity.getProducts() != null) {


### PR DESCRIPTION
- Se corrigió un bug que impedía guardar correctamente los IDs de las sucursales (branches) al mapear franquicias desde DTO.
- Se añadió endpoint para eliminar todas las franquicias (propósito: pruebas y limpieza de datos).